### PR TITLE
Adds multiple API endpoints to the Node quickstart example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.DS_Store
+nodejs/sustainability-get.json
+nodejs/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -353,6 +353,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
 .DS_Store
-nodejs/sustainability-get.json
-nodejs/package-lock.json

--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+*.pdf
+files

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.19.1",
     "dotenv": "^16.0.0",
     "express": "^4.17.2",
     "express-session": "^1.17.2",

--- a/nodejs/src/index.html
+++ b/nodejs/src/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Link SDK Demo</title>
-    
+
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
     <style>
       .btn-demo {
@@ -17,17 +18,22 @@
       }
     </style>
   </head>
+
   <body>
     <main class="container">
       <hgroup>
         <h1>Link Quickstart</h1>
         <p>
-          This is a minimal app that implements Deck using a very basic HTML/vanilla JS frontend with an Express/Node backend. 
-          After linking a sample utility account, the app retrieves information associated with the account and renders it on the home page.
+          This is a minimal app that implements Deck using a very basic HTML/vanilla JS frontend with an Express/Node
+          backend. After linking a sample utility account, the app retrieves information associated with the account and
+          renders it on the home page.
         </p>
       </hgroup>
 
       <button class="btn-demo" onClick="startLink()">Link Account</button>
+      <button class="btn-demo" onClick="getBillData()" disabled>bill/get</button>
+      <button class="btn-demo" onClick="getSustainabilityData()" disabled>sustainability/get</button>
+
       <pre class="js-events"></pre>
 
       <div style="height: 1200px"></div>
@@ -37,4 +43,5 @@
     <script src="https://link.deck.co/link-initialize.js"></script>
     <script src="index.js"></script>
   </body>
+
 </html>

--- a/nodejs/src/index.html
+++ b/nodejs/src/index.html
@@ -16,6 +16,15 @@
         width: auto;
         margin-right: 28px;
       }
+
+      .file-links a {
+        display: block;
+        margin-top: 16px;
+      }
+
+      .js-events {
+        max-height: 55vh;
+      }
     </style>
   </head>
 
@@ -30,9 +39,12 @@
         </p>
       </hgroup>
 
-      <button class="btn-demo" onClick="startLink()">Link Account</button>
+      <button class="btn-demo" onClick="startLink(event)">Link Account</button>
       <button class="btn-demo" onClick="getBillData()" disabled>bill/get</button>
+      <button class="btn-demo" onClick="getBillStatement()" disabled>bill/statement</button>
       <button class="btn-demo" onClick="getSustainabilityData()" disabled>sustainability/get</button>
+      <button class="btn-demo sustainability-file" onClick="getSustainabilityFile()"
+        disabled>sustainability/statement/file</button>
 
       <pre class="js-events"></pre>
 

--- a/nodejs/src/index.js
+++ b/nodejs/src/index.js
@@ -1,4 +1,4 @@
-;(function linkSdkIIFE(context) {
+(function linkSdkIIFE(context) {
   const client = {
     _api: "http://127.0.0.1:8080",
     _headers: {
@@ -9,9 +9,9 @@
       const response = await fetch(`${this._api}/api/create_link_token`, {
         method: "POST",
         headers: this._headers,
-      })
+      });
 
-      return response.json()
+      return response.json();
     },
 
     async exchangePublicToken(public_token) {
@@ -19,52 +19,70 @@
         method: "POST",
         headers: this._headers,
         body: JSON.stringify({ public_token }),
-      })
-      return response.json()
+      });
+      return response.json();
     },
 
-    async getData() {
-      const response = await fetch(`${this._api}/api/data`, {
+    async getData(endpoint) {
+      const response = await fetch(`${this._api}/${endpoint}`, {
         method: "GET",
         headers: this._headers,
-      })
-      return response.json()
+      });
+      return response.json();
     },
-  }
+  };
+
   function logEvent(eventText) {
-    const timestamp = new Date().toLocaleTimeString()
+    const timestamp = new Date().toLocaleTimeString();
     document.querySelector(
       ".js-events"
-    ).textContent += `[${timestamp}] ${eventText}\n`
+    ).textContent += `[${timestamp}] ${eventText}\n`;
   }
 
   async function startLink() {
-    const { link_token: token } = await client.createToken()
+    const { link_token: token } = await client.createToken();
 
     const handler = Deck.create({
       token,
 
       // A single source can be specified, this will skip the source select screen.
       // For the skip to work, make sure that the source specified here would appear normally on the source select screen.
-      // source_id: '09320c5d-8552-47df-8aa3-98fe1c0b5505',
-      
+      // source_id: "09320c5d-8552-47df-8aa3-98fe1c0b5505",
+
       onExit() {
-        logEvent("onExit()")
+        logEvent("onExit()");
       },
       async onSuccess({ public_token }) {
-        handler.exit()
-        logEvent("onSuccess(): Exchanging public token for access token...")
-        await client.exchangePublicToken(public_token)
-        logEvent("onSuccess(): Done! Fetching data...")
-
-        const { Balance } = await client.getData()
-        logEvent(JSON.stringify(Balance, undefined, 2))
+        handler.exit();
+        logEvent("onSuccess(): Exchanging public token for access token...");
+        await client.exchangePublicToken(public_token);
+        logEvent("onSuccess(): Done!");
+        logEvent("Continue by selecting an action.");
+        document.querySelectorAll(".btn-demo").forEach((btn) => {
+          btn.disabled = false;
+        });
       },
-    })
+    });
 
-    handler.open()
+    handler.open();
   }
 
-  context.startLink = startLink
-  startLink()
-})(window)
+  async function getBillData() {
+    logEvent("Getting bill data...");
+    const { Balance } = await client.getData("api/bill");
+    logEvent(JSON.stringify(Balance, undefined, 2));
+  }
+
+  async function getSustainabilityData() {
+    logEvent("Getting sustainability data...");
+    const { Balance } = await client.getData("api/sustainability");
+    logEvent(JSON.stringify(Balance, undefined, 2));
+  }
+
+  context.startLink = startLink;
+  context.getBillData = getBillData;
+  context.getSustainabilityData = getSustainabilityData;
+
+  // Uncomment to start the Link flow automatically
+  // startLink();
+})(window);

--- a/nodejs/src/server.js
+++ b/nodejs/src/server.js
@@ -2,30 +2,31 @@
 server.js – Uses Express to defines routes that call Deck endpoints in the Sandbox environment.
 */
 
-require("dotenv").config()
-const express = require("express")
-const bodyParser = require("body-parser")
-const session = require("express-session")
-const path = require("path")
-const app = express()
+require("dotenv").config();
+const express = require("express");
+const session = require("express-session");
+const path = require("path");
+const util = require("util");
+const app = express();
 
 app.use(
   // FOR DEMO PURPOSES ONLY
   // Use an actual secret key in production
   session({ secret: "bosco", saveUninitialized: true, resave: true })
-)
+);
 
-app.use(bodyParser.urlencoded({ extended: false }))
-app.use(bodyParser.json())
+// Replace body-parser with native express methods
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
 
 app.get("/", async (req, res) => {
-  res.sendFile(path.join(__dirname, "index.html"))
-})
+  res.sendFile(path.join(__dirname, "index.html"));
+});
 
 // Serve index.js
 app.get("/index.js", async (req, res) => {
-  res.sendFile(path.join(__dirname, "index.js"))
-})
+  res.sendFile(path.join(__dirname, "index.js"));
+});
 
 const client = {
   _api: "https://sandbox.deck.co/api/v1",
@@ -38,15 +39,15 @@ const client = {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(bodyJson),
-    })
+    });
   },
-}
+};
 
 // Creates a Link token and return it
 app.post("/api/create_link_token", async (req, res, next) => {
-  const response = await client.post("link/token/create")
-  res.json(await response.json())
-})
+  const response = await client.post("link/token/create");
+  res.json(await response.json());
+});
 
 // Exchanges the public token from Deck Link for an access token
 app.post("/api/exchange_public_token", async (req, res, next) => {
@@ -55,24 +56,51 @@ app.post("/api/exchange_public_token", async (req, res, next) => {
     {
       public_token: req.body.public_token,
     }
-  )
+  );
 
   // FOR DEMO PURPOSES ONLY
   // Store access_token in DB instead of session storage
-  const data = await exchangeResponse.json()
-  req.session.access_token = data.access_token
-  res.json(true)
-})
+  const data = await exchangeResponse.json();
+  req.session.access_token = data.access_token;
+  res.json(true);
+});
 
-// Fetches balance data
-app.get("/api/data", async (req, res, next) => {
-  const access_token = req.session.access_token
-  const balanceResponse = await client.post("bill/get", { access_token })
-  const Balance = await balanceResponse.json()
-
+app.get("/api/bill", async (req, res, next) => {
+  const access_token = req.session.access_token;
+  console.log("## Calling Deck bill/get...");
+  const balanceResponse = await client.post("bill/get", {
+    access_token,
+  });
+  console.log("-------\nResponse:\n", balanceResponse);
+  const Balance = await balanceResponse.json();
+  console.log(
+    "-------\nBody:\n",
+    util.inspect(Balance, { showHidden: false, depth: null, colors: true })
+  );
   res.json({
     Balance,
-  })
-})
+  });
+});
 
-app.listen(process.env.PORT || 8080)
+app.get("/api/sustainability", async (req, res, next) => {
+  const access_token = req.session.access_token;
+  console.log("## Calling Deck sustainability/get...");
+  const balanceResponse = await client.post("sustainability/get", {
+    access_token,
+  });
+  console.log("-------\nResponse:\n", balanceResponse);
+  const Balance = await balanceResponse.json();
+  console.log(
+    "-------\nBody:\n",
+    util.inspect(Balance, { showHidden: false, depth: null, colors: true })
+  );
+  res.json({
+    Balance,
+  });
+});
+
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+  console.log(`http://127.0.0.1:${PORT}`);
+});


### PR DESCRIPTION
- Adds UI to test additional Deck API endpoints.
- Some QOL in the UI: disabling buttons that won't work yet, disabling link button after click while the Deck widget is warming up, scrolling log content, etc
- Refactors out `body-parser`, uses native Express methods
- Lots of semicolons and formatting thanks to my formatter (sorry) (not sorry?)

Before linking:
![image](https://github.com/user-attachments/assets/8076217b-9768-43fe-85c9-2cd85def2177)

After linking an account:
<img width="1196" alt="Screenshot 2025-02-05 at 5 54 37 PM" src="https://github.com/user-attachments/assets/2ec0bc75-8a02-47b4-9fd7-2ffe16e9a0ed" />
